### PR TITLE
better merge conflict scopes

### DIFF
--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -157,15 +157,9 @@ contexts:
     - match: '\s+'
       scope: meta.whitespace.es
     # MERGE CONFLICTS
-    - match: '<<<<<<< (.+)'
-      scope: 'invalid.merge-conflict.delimiter'
-      push:
-        - meta_scope: invalid.merge-conflict
-        - match: '======='
-          scope: 'invalid.merge-conflict.delimiter'
-        - match: '>>>>>>> (.+)'
-          scope: 'invalid.merge-conflict.delimiter'
-          pop: true
+    - match: '<<<<<<< (.+)\n'
+      scope: 'invalid.merge-conflict.delimiter.our-changes'
+      push: merge_conflict_our_changes
     # COMMENTS
     - match: '((\/\/))'
       captures:
@@ -198,6 +192,18 @@ contexts:
           scope: meta.comment.box-drawing.es
         - match: '\b(?i:todo|hack)\b'
           scope: comment.line.todo.es
+
+  merge_conflict_our_changes:
+    - meta_scope: invalid.merge-conflict.our-changes
+    - match: '=======\n'
+      scope: 'invalid.merge-conflict.delimiter.separator'
+      set: merge_conflict_their_changes
+
+  merge_conflict_their_changes:
+    - meta_scope: invalid.merge-conflict.thier-changes
+    - match: '>>>>>>> (.+)\n'
+      scope: 'invalid.merge-conflict.delimiter.their-changes'
+      pop: true
 
   # If no match has been made, gently and quietly pop
   else_pop:

--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -200,7 +200,7 @@ contexts:
       set: merge_conflict_their_changes
 
   merge_conflict_their_changes:
-    - meta_scope: invalid.merge-conflict.thier-changes
+    - meta_scope: invalid.merge-conflict.their-changes
     - match: '>>>>>>> (.+)\n'
       scope: 'invalid.merge-conflict.delimiter.their-changes'
       pop: true


### PR DESCRIPTION
Before:
![screen shot 2017-05-31 at 13 22 24](https://cloud.githubusercontent.com/assets/3202/26633288/2cba3024-4613-11e7-92e9-7d7694ad6bd6.png)

After:
![screen shot 2017-05-31 at 14 38 28](https://cloud.githubusercontent.com/assets/3202/26632161/fdeb2f04-460e-11e7-994d-b93951c6175b.png)

With these rules added to the color scheme (in yaml format for brevity)
```yaml
-   name: Merge Conflicts Delimiter Our Changes
    scope: invalid.merge-conflict.delimiter.our-changes
    settings:
        background: '#178BFB'
-   name: Merge Conflicts Delimiter Their Changes
    scope: invalid.merge-conflict.delimiter.their-changes
    settings:
        background: '#2CB585'
-   name: Merge Conflicts Our Changes Content
    scope: invalid.merge-conflict.our-changes
    settings:
        background: '#178BFB33'
-   name: Merge Conflicts Thier Changes Content
    scope: invalid.merge-conflict.thier-changes
    settings:
        background: '#2CB58533'
-   name: Merge Conflicts Separator
    scope: invalid.merge-conflict.delimiter.separator
    settings:
        background: '#00161B'
        foreground: '#5A707577'
```