### PR TITLE
fixed auto-indent for opening parens and square brackets

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -25,7 +25,7 @@
 			{
 				"key": "preceding_text",
 				"operator": "regex_contains",
-				"operand": "[([]$"
+				"operand": "(\\([^(]*|\\[[^[]*)$"
 			},
 			{
 				"key": "selector",


### PR DESCRIPTION
Last commit to make this feature work properly. Auto-indents multiline arguments in parens and multiline values in array literals.

![ecmascript-autoindent](https://user-images.githubusercontent.com/1456400/36580940-46894204-181f-11e8-9532-24e5575a6a28.gif)
