### PR TITLE
Correct arrow function name case scopes

### DIFF
--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -1157,28 +1157,28 @@ contexts:
       captures:
         1: meta.function.js entity.name.function.js # ^BS
         2: meta.symbol-helper.generator.es # -BS
-        3: variable.other.readwrite.allCap.es # -BS
-        4: variable.other.readwrite.initCap.es
-        5: variable.other.readwrite.es
-        6: entity.name.function.generator.es
+        3: entity.name.function.generator.es
+        4: variable.other.readwrite.allCap.es # -BS
+        5: variable.other.readwrite.initCap.es
+        6: variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '((({{allThreeIDs}})))(?=\s*=\s*async\s+function{{idEnd}})'
       captures:
         1: meta.function.js entity.name.function.js # ^BS
         2: meta.symbol-helper.function.es
-        3: variable.other.readwrite.allCap.es # -BS
-        4: variable.other.readwrite.initCap.es
-        5: variable.other.readwrite.es
-        6: entity.name.function.async.es
+        3: entity.name.function.async.es
+        4: variable.other.readwrite.allCap.es # -BS
+        5: variable.other.readwrite.initCap.es
+        6: variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '((({{allThreeIDs}})))(?=\s*=\s*function{{idEnd}})'
       captures:
         1: meta.function.js entity.name.function.js # ^BS
         2: meta.symbol-helper.function.es
-        3: variable.other.readwrite.allCap.es # -BS
-        4: variable.other.readwrite.initCap.es
-        5: variable.other.readwrite.es
-        6: entity.name.function.es
+        3: entity.name.function.es
+        4: variable.other.readwrite.allCap.es # -BS
+        5: variable.other.readwrite.initCap.es
+        6: variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '(({{allThreeIDs}}))(?=\s*=\s*class\s*(?:\{|extends{idEnd}))'
       captures:
@@ -1205,10 +1205,10 @@ contexts:
       captures:
         1: meta.function.arrow.js entity.name.function.js # ^BS
         2: meta.symbol-helper.arrow.es
-        3: variable.other.readwrite.allCap.es
-        4: variable.other.readwrite.initCap.es
-        5: variable.other.readwrite.es
-        6: entity.name.function.es
+        3: entity.name.function.es
+        4: variable.other.readwrite.allCap.es
+        5: variable.other.readwrite.initCap.es
+        6: variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '{{allThreeIDs}}'
       captures:

--- a/nested/build/ecmascript/ecmascript-nest.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-nest.sublime-syntax
@@ -1084,28 +1084,28 @@ contexts:
       captures:
         '1': meta.function.js entity.name.function.js
         '2': meta.symbol-helper.generator.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.generator.es
+        '3': entity.name.function.generator.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '((({{allThreeIDs}})))(?=\s*=\s*async\s+function{{idEnd}})'
       captures:
         '1': meta.function.js entity.name.function.js
         '2': meta.symbol-helper.function.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.async.es
+        '3': entity.name.function.async.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '((({{allThreeIDs}})))(?=\s*=\s*function{{idEnd}})'
       captures:
         '1': meta.function.js entity.name.function.js
         '2': meta.symbol-helper.function.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.es
+        '3': entity.name.function.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '(({{allThreeIDs}}))(?=\s*=\s*class\s*(?:\{|extends{idEnd}))'
       captures:
@@ -1132,10 +1132,10 @@ contexts:
       captures:
         '1': meta.function.arrow.js entity.name.function.js
         '2': meta.symbol-helper.arrow.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.es
+        '3': entity.name.function.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '{{allThreeIDs}}'
       captures:

--- a/nested/build/ecmascript/ecmascript-safe.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-safe.sublime-syntax
@@ -1019,28 +1019,28 @@ contexts:
       captures:
         '1': meta.function.js entity.name.function.js
         '2': meta.symbol-helper.generator.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.generator.es
+        '3': entity.name.function.generator.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '((({{allThreeIDs}})))(?=\s*=\s*async\s+function{{idEnd}})'
       captures:
         '1': meta.function.js entity.name.function.js
         '2': meta.symbol-helper.function.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.async.es
+        '3': entity.name.function.async.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '((({{allThreeIDs}})))(?=\s*=\s*function{{idEnd}})'
       captures:
         '1': meta.function.js entity.name.function.js
         '2': meta.symbol-helper.function.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.es
+        '3': entity.name.function.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '(({{allThreeIDs}}))(?=\s*=\s*class\s*(?:\{|extends{idEnd}))'
       captures:
@@ -1067,10 +1067,10 @@ contexts:
       captures:
         '1': meta.function.arrow.js entity.name.function.js
         '2': meta.symbol-helper.arrow.es
-        '3': variable.other.readwrite.allCap.es
-        '4': variable.other.readwrite.initCap.es
-        '5': variable.other.readwrite.es
-        '6': entity.name.function.es
+        '3': entity.name.function.es
+        '4': variable.other.readwrite.allCap.es
+        '5': variable.other.readwrite.initCap.es
+        '6': variable.other.readwrite.es
       set: constLetVarDeclaration_AFTER_BINDING
     - match: '{{allThreeIDs}}'
       captures:


### PR DESCRIPTION
```js
const shouldNotBeAllCaps = () => {}
const shouldNotBeAllCaps = function () {}
const shouldNotBeAllCaps = function* () {}
const shouldNotBeAllCaps = async function () {}
const ShouldBeInitCap = () => {}
```