### PR TITLE
remove `punctuation.definition.string.interpolated.begin.es` on tag name

### DIFF
--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -2911,7 +2911,7 @@ contexts:
     - match: '\/'
       scope: punctuation.definition.string.regexp.begin.es
       set: [ ae_AFTER_VALUE, regex_AFTER_OPEN ]
-    - match: '((({{identifier}})))\s*(`)'
+    - match: '(({{identifier}}))\s*(`)'
       captures:
         1: entity.quasi.tag.name.js # ^BS
         2: variable.other.readwrite.tag.es
@@ -3771,7 +3771,7 @@ contexts:
     - match: '\/'
       scope: punctuation.definition.string.regexp.begin.es
       set: [ ae_NO_IN_AFTER_VALUE, regex_AFTER_OPEN ]
-    - match: '((({{identifier}})))\s*(`)'
+    - match: '(({{identifier}}))\s*(`)'
       captures:
         1: entity.quasi.tag.name.js
         2: variable.other.readwrite.tag.es

--- a/nested/build/ecmascript/ecmascript-nest.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-nest.sublime-syntax
@@ -2881,7 +2881,7 @@ contexts:
       set:
         - ae_AFTER_VALUE
         - regex_AFTER_OPEN
-    - match: '((({{identifier}})))\s*(\\`)'
+    - match: '(({{identifier}}))\s*(\\`)'
       captures:
         '1': entity.quasi.tag.name.js
         '2': variable.other.readwrite.tag.es
@@ -3803,7 +3803,7 @@ contexts:
       set:
         - ae_NO_IN_AFTER_VALUE
         - regex_AFTER_OPEN
-    - match: '((({{identifier}})))\s*(\\`)'
+    - match: '(({{identifier}}))\s*(\\`)'
       captures:
         '1': entity.quasi.tag.name.js
         '2': variable.other.readwrite.tag.es

--- a/nested/build/ecmascript/ecmascript-safe.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-safe.sublime-syntax
@@ -2660,7 +2660,7 @@ contexts:
       set:
         - ae_AFTER_VALUE
         - regex_AFTER_OPEN
-    - match: '((({{identifier}})))\s*(`)'
+    - match: '(({{identifier}}))\s*(`)'
       captures:
         '1': entity.quasi.tag.name.js
         '2': variable.other.readwrite.tag.es
@@ -3567,7 +3567,7 @@ contexts:
       set:
         - ae_NO_IN_AFTER_VALUE
         - regex_AFTER_OPEN
-    - match: '((({{identifier}})))\s*(`)'
+    - match: '(({{identifier}}))\s*(`)'
       captures:
         '1': entity.quasi.tag.name.js
         '2': variable.other.readwrite.tag.es


### PR DESCRIPTION
```js
shouldntHavePunctuationScope``
```
![image](https://user-images.githubusercontent.com/1020347/45272677-3daa1c80-b4e1-11e8-94b3-37a2af85016e.png)
