### PR TITLE
Toggle/Insert Commands for Nested Syntax Directives

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -39,5 +39,52 @@
 				"match_all": true,
 			}
 		]
+	},
+	{
+		"keys": ["primary+'"],
+		"command": "toggle_nested_syntax",
+		"args": {},
+		"context": [
+			{
+				"key": "auto_complete_visible",
+				"operator": "equal",
+				"operand": false
+			},
+			{
+				"key": "selector",
+				"operator": "equal",
+				"operand": "source.es string.interpolated.es, source.es meta.interpolation.syntax",
+				"match_all": true,
+			},
+			{
+				"key": "num_selections",
+				"operator": "equal",
+				"operand": 1
+			},
+		]
+	},
+	{
+		"keys": ["primary+'"],
+		"command": "insert_nested_syntax",
+		"args": {},
+		"context": [
+			{
+				"key": "auto_complete_visible",
+				"operator": "equal",
+				"operand": false
+			},
+			{
+				"key": "selector",
+				"operator": "equal",
+				"operand": "source.es & (meta.whitespace.es | punctuation.definition.arguments.end.es | punctuation.definition.array.end.es | invalid.illegal.token.es) - string.interpolated.es - meta.interpolation.syntax",
+				"match_all": true,
+			},
+			{
+				"key": "selection_empty",
+				"operator": "equal",
+				"operand": true,
+				"match_all": true,
+			}
+		]
 	}
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -25,17 +25,17 @@
 			{
 				"key": "preceding_text",
 				"operator": "regex_contains",
-				"operand": "[([]$"
+				"operand": "[([`]$"
 			},
 			{
 				"key": "following_text",
 				"operator": "regex_contains",
-				"operand": "^[)\\]]",
+				"operand": "^[)\\]`]",
 			},
 			{
 				"key": "selector",
 				"operator": "equal",
-				"operand": "source.es meta.brace.square.js, source.es meta.brace.round.js",
+				"operand": "source.es & (meta.brace.square.js | meta.brace.round.js | string.interpolated.es)",
 				"match_all": true,
 			}
 		]
@@ -53,7 +53,7 @@
 			{
 				"key": "selector",
 				"operator": "equal",
-				"operand": "source.es string.interpolated.es, source.es meta.interpolation.syntax",
+				"operand": "source.es & (string.interpolated.es | meta.interpolation.syntax)",
 				"match_all": true,
 			},
 			{

--- a/commands.py
+++ b/commands.py
@@ -127,6 +127,7 @@ class ToggleNestedSyntaxCommand(sublime_plugin.TextCommand):
       i_traverse = self.over(i_cursor, ss_template_literal)
 
       # update cursor
+      y_cursor.b = y_cursor.end()
       y_cursor.a = i_literal
 
       # add cursor

--- a/commands.py
+++ b/commands.py
@@ -1,0 +1,160 @@
+import sublime, sublime_plugin
+import re
+
+ss_interp_element = 'punctuation.definition.string.interpolated.element'
+ss_template_literal = '(string.interpolated.es | meta.interpolation.syntax | entity.quasi.tag.name) - '+ss_interp_element+'.end.es'
+
+r_directive = r'(\s*syntax:\s*)([\w\.]*)(\s*)'
+
+class ToggleNestedSyntaxCommand(sublime_plugin.TextCommand):
+  def behind(self, i_traverse, ss_behind, b_against=False):
+    while i_traverse > 0 and self.view.match_selector(i_traverse, ss_behind): i_traverse -= 1
+    if b_against: i_traverse += 1
+    return i_traverse
+
+  def over(self, i_traverse, ss_over):
+    while self.view.match_selector(i_traverse, ss_over): i_traverse += 1
+    return i_traverse
+
+  def run(self, edit):
+    d_view = self.view
+
+    # ref selections
+    a_sels = list(d_view.sel())
+
+    # clear selections
+    d_view.sel().clear()
+
+    # cumulative gap
+    c_gap = 0
+
+    # each selection
+    for y_cursor in a_sels:
+      y_region = None
+
+      # for multi-selection
+      y_cursor.a += c_gap
+      y_cursor.b += c_gap
+
+      # traversal point
+      i_traverse = i_cursor = y_cursor.begin()
+
+      c_loops = 0
+
+      # find beginning of interpolated string
+      while d_view.match_selector(i_traverse, ss_template_literal):
+        if c_loops > 15: break
+        c_loops += 1
+
+        # traverse beyond template literal
+        i_traverse = self.behind(i_traverse, ss_template_literal)
+
+        # reached bof
+        if i_traverse == 0: break
+
+        # boundary is interpolated element
+        if d_view.match_selector(i_traverse, ss_interp_element+'.end.es'):
+          # traverse over interpolated element
+          while i_traverse > 0 and not d_view.match_selector(i_traverse, ss_interp_element+'.begin.es'):
+            i_traverse -= 1
+
+          # keep traversing
+          continue
+
+        # boundary is anything else; stop traversing
+        else:
+          break
+
+      # start of template literal
+      i_literal = i_traverse + 1
+
+      # span whitespace and then block comment
+      i_traverse = self.behind(i_traverse, 'meta.whitespace.es')
+      i_traverse = self.behind(i_traverse, 'comment.block.es', True)
+
+      # at block comment
+      if d_view.match_selector(i_traverse, 'comment.block.es & meta.comment.border.es'):
+        i_block = i_traverse
+
+        # move forward past border
+        i_traverse = self.over(i_traverse, 'meta.comment.border.es')
+        
+        # match syntax directive
+        y_directive = d_view.find(r_directive, i_traverse)
+        if y_directive is not None and not y_directive.empty() and y_directive.begin() < i_literal:
+          # toggle off directive
+          d_view.erase(edit, sublime.Region(i_block, i_literal))
+
+          # calculate gap
+          n_gap = i_literal - i_block
+
+          # update cursor with offset
+          y_cursor.a -= n_gap
+          y_cursor.b -= n_gap
+
+          c_gap -= n_gap
+
+          # add cursor
+          d_view.sel().add(y_cursor)
+
+          # next selection
+          continue;
+
+      # pre region
+      y_region_pre = sublime.Region(i_literal, i_cursor)
+
+      # offset
+      nl_offset = 0
+
+      # pre text
+      s_pre = d_view.substr(y_region_pre)
+      nl_offset += len(s_pre)
+      s_pre = re.sub(r'\$', r'\\$', s_pre);
+
+      # selection
+      s_sel = d_view.substr(y_cursor)
+      nl_offset += len(s_sel)
+      s_sel = "${0:"+re.sub(r'\$', r'\\$', s_sel)+"}"
+
+      # auto-gobble upcoming insert_snippet's auto-indentation
+      i_bol = d_view.expand_by_class(i_literal, sublime.CLASS_LINE_START).begin()
+      s_line = d_view.substr(sublime.Region(i_bol, i_literal))
+      m_gobble = re.match(r'^([ \t]*)', s_line)
+      if m_gobble is not None:
+        s_pre = re.sub(r'\n'+m_gobble.group(1), '\n', s_pre)
+
+      # post text
+      i_traverse = self.over(i_cursor, ss_template_literal)
+
+      # update cursor
+      y_cursor.a = i_literal
+
+      # add cursor
+      d_view.sel().add(y_cursor)
+
+      # add directive
+      s_dir = "/* syntax: ${1:language} */ "
+      c_gap += len(s_dir) - 5
+      s_snippet = s_dir+s_pre+s_sel
+
+      # update cumulative gap
+      c_gap += nl_offset
+
+      # insert code
+      d_view.run_command('insert_snippet', {"contents": s_snippet})
+
+
+
+class InsertNestedSyntaxCommand(sublime_plugin.TextCommand):
+  def run(self, edit):
+    d_view = self.view
+
+    # ref selections
+    a_sels = list(d_view.sel())
+
+    # each selection
+    for y_cursor in a_sels:
+      y_region = None
+
+      s_snippet = "/* syntax: ${1:language} */ `$0`"
+      d_view.run_command('insert_snippet', {"contents": s_snippet})

--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -130,26 +130,27 @@ variables:
   syntaxDirectiveHead: '(\s*syntax\s*:\s*)'
   syntaxDirectiveTail: '\s*(\*\/)\s*(({{identifier}}))?(?=\s*`)'
 
-  syntaxDirective_CSS:   '[Cc](?:ss|SS){{syntaxDirectiveTail}}'
-  syntaxDirective_CSS_STYLE:   '[Cc](?:ss|SS)[.#][Ss]tyle{{syntaxDirectiveTail}}'
-  syntaxDirective_DOT:   '[Dd](?:ot|OT){{syntaxDirectiveTail}}'
-  syntaxDirective_GLSL:  '[Gg](?:lsl|LSL){{syntaxDirectiveTail}}'
-  syntaxDirective_HTML:  '[Hh](?:tml|TML){{syntaxDirectiveTail}}'
-  syntaxDirective_JS:    '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_VALUE:    '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Vv]alue{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_METHOD:    '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Mm]ethod{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_REGEXP:    '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Rr]egexp?{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_OBJECT_LITERAL:    '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Oo]bject-[Ll]iteral{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_SIMPLE:    '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?-[Ss](?:imple|IMPLE){{syntaxDirectiveTail}}'
-  syntaxDirective_JSON:  '[Jj](?:son|SON){{syntaxDirectiveTail}}'
-  syntaxDirective_LUA:  '[Ll](?:ua|UA){{syntaxDirectiveTail}}'
-  syntaxDirective_MARKDOWN:  '[Mm](?:ark[Dd](?:own|OWN)|ARKDOWN|[Dd]){{syntaxDirectiveTail}}'
-  syntaxDirective_SHELL: '(?:[Bb](?:ash|ASH)|[Ss](?:hell|HELL)){{syntaxDirectiveTail}}'
-  syntaxDirective_SQL:   '[Ss](?:ql|QL){{syntaxDirectiveTail}}'
-  syntaxDirective_SUBLIME_SYNTAX:   '[Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX){{syntaxDirectiveTail}}'
-  syntaxDirective_SUBLIME_SYNTAX_CONTEXT:   '[Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX)[.#][Cc]ontexts?{{syntaxDirectiveTail}}'
-  syntaxDirective_XML:   '[Xx](?:ml|ML){{syntaxDirectiveTail}}'
-  syntaxDirective_YAML:  '[Yy](?:aml|AML){{syntaxDirectiveTail}}'
+  syntaxDirective_CSS:                    '([Cc](?:ss|SS))(){{syntaxDirectiveTail}}'
+  syntaxDirective_CSS_STYLE:              '([Cc](?:ss|SS))([.#][Ss]tyle){{syntaxDirectiveTail}}'
+  syntaxDirective_DOT:                    '([Dd](?:ot|OT))(){{syntaxDirectiveTail}}'
+  syntaxDirective_GLSL:                   '([Gg](?:lsl|LSL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_HTML:                   '([Hh](?:tml|TML))(){{syntaxDirectiveTail}}'
+  syntaxDirective_JS:                     '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)(){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_VALUE:               '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Vv]alue){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_METHOD:              '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Mm]ethod){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_REGEXP:              '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Rr]egexp?){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_OBJECT_LITERAL:      '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Oo]bject-[Ll]iteral){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_SIMPLE:              '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?-[Ss](?:imple|IMPLE)){{syntaxDirectiveTail}}'
+  syntaxDirective_JSON:                   '([Jj](?:son|SON))(){{syntaxDirectiveTail}}'
+  syntaxDirective_LUA:                    '([Ll](?:ua|UA))(){{syntaxDirectiveTail}}'
+  syntaxDirective_MARKDOWN:               '([Mm](?:ark[Dd](?:own|OWN)|ARKDOWN|[Dd]))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SHELL:                  '([Bb](?:ash|ASH)|[Ss](?:hell|HELL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SQL:                    '([Ss](?:ql|QL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SUBLIME_SYNTAX:         '([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SUBLIME_SYNTAX_CONTEXT: '([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))([.#][Cc]ontexts?){{syntaxDirectiveTail}}'
+  syntaxDirective_SUBLIME_SYNTAX_REGEX:   '([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))([.#][Rr]egexp?){{syntaxDirectiveTail}}'
+  syntaxDirective_XML:                    '([Xx](?:ml|ML))(){{syntaxDirectiveTail}}'
+  syntaxDirective_YAML:                   '([Yy](?:aml|AML))(){{syntaxDirectiveTail}}'
 
   syntaxDirective: >-
     (?x)
@@ -172,6 +173,7 @@ variables:
         | {{syntaxDirective_SQL}}
         | {{syntaxDirective_SUBLIME_SYNTAX}}
         | {{syntaxDirective_SUBLIME_SYNTAX_CONTEXT}}
+        | {{syntaxDirective_SUBLIME_SYNTAX_REGEX}}
         | {{syntaxDirective_XML}}
         | {{syntaxDirective_YAML}}
       )
@@ -5215,7 +5217,7 @@ contexts:
       captures:
         1: meta.comment.border.es
         2: punctuation.definition.comment.begin.es
-        3: comment.block.es
+        3: meta.directive.syntax.keyword.es
       set: [ ae_AFTER_VALUE, syntax_EXIT, syntax_DIRECTIVE ]
     - include: block_comment
 
@@ -5224,7 +5226,7 @@ contexts:
       captures:
         1: meta.comment.border.es
         2: punctuation.definition.comment.begin.es
-        3: comment.block.es
+        3: meta.directive.syntax.keyword.es
       set: [ ae_NO_IN_AFTER_VALUE, syntax_EXIT, syntax_DIRECTIVE ]
     - include: block_comment
 
@@ -5305,123 +5307,171 @@ contexts:
     - meta_include_prototype: false
     - match: '{{syntaxDirective_CSS}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_CSS, syntax_CSS_OPEN ]
     - match: '{{syntaxDirective_CSS_STYLE}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_CSS, syntax_CSS_RULE_LIST_BODY_OPEN ]
     - match: '{{syntaxDirective_DOT}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_DOT, syntax_DOT_OPEN ]
     - match: '{{syntaxDirective_GLSL}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_GLSL, syntax_GLSL_OPEN ]
     - match: '{{syntaxDirective_HTML}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_HTML, syntax_HTML_OPEN ]
     - match: '{{syntaxDirective_JS}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_JS, syntax_JS_OPEN ]
     - match: '{{syntaxDirective_JS_VALUE}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_JS, syntax_JS_VALUE_OPEN ]
     - match: '{{syntaxDirective_JS_METHOD}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_JS, syntax_JS_METHOD_OPEN ]
     - match: '{{syntaxDirective_JS_REGEXP}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_JS, syntax_JS_REGEXP_OPEN ]
     - match: '{{syntaxDirective_JS_OBJECT_LITERAL}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_JS, syntax_JS_OBJECT_LITERAL_OPEN ]
     - match: '{{syntaxDirective_JS_SIMPLE}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_JS, syntax_JS_SIMPLE_OPEN ]
     - match: '{{syntaxDirective_JSON}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_JSON, syntax_JSON_OPEN ]
     - match: '{{syntaxDirective_LUA}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_LUA, syntax_LUA_OPEN ]
     - match: '{{syntaxDirective_MARKDOWN}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_MARKDOWN, syntax_MARKDOWN_OPEN ]
     - match: '{{syntaxDirective_SHELL}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_SHELL, syntax_SHELL_OPEN ]
     - match: '{{syntaxDirective_SQL}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_SQL, syntax_SQL_OPEN ]
     - match: '{{syntaxDirective_SUBLIME_SYNTAX}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_SUBLIME_SYNTAX, syntax_SUBLIME_SYNTAX_OPEN ]
     - match: '{{syntaxDirective_SUBLIME_SYNTAX_CONTEXT}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_SUBLIME_SYNTAX, syntax_SUBLIME_SYNTAX_CONTEXT_OPEN ]
+    - match: '{{syntaxDirective_SUBLIME_SYNTAX_REGEX}}'
+      captures:
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
+      set: [ syntax_meta_SUBLIME_SYNTAX, syntax_SUBLIME_SYNTAX_REGEX_OPEN ]
     - match: '{{syntaxDirective_XML}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_XML, syntax_XML_OPEN ]
     - match: '{{syntaxDirective_YAML}}'
       captures:
-        1: punctuation.definition.comment.end.es
-        2: entity.quasi.tag.name.js # ^BS
-        3: variable.other.readwrite.tag.es
+        1: meta.directive.syntax.language.es
+        2: meta.directive.syntax.context.es
+        3: punctuation.definition.comment.end.es
+        4: entity.quasi.tag.name.js # ^BS
+        5: variable.other.readwrite.tag.es
       set: [ syntax_meta_YAML, syntax_YAML_OPEN ]
 
 # CSS SYNTAX ###################################################################
@@ -5779,6 +5829,14 @@ contexts:
     - match: '`'
       scope: string.interpolated.es punctuation.definition.string.interpolated.begin.es
       set: scope:source.yaml.sublime.syntax.nested.es#contexts_block
+      with_prototype:
+        - include: syntax_AFTER_OPEN
+
+  syntax_SUBLIME_SYNTAX_REGEX_OPEN:
+    - meta_include_prototype: false
+    - match: '`'
+      scope: string.interpolated.es punctuation.definition.string.interpolated.begin.es
+      set: scope:source.yaml.sublime.syntax.nested.es#expect_regexp
       with_prototype:
         - include: syntax_AFTER_OPEN
 

--- a/excelsior.YAML-tmTheme
+++ b/excelsior.YAML-tmTheme
@@ -128,6 +128,19 @@ settings:
     foreground: '#B2BD95'
     fontStyle: 'italic'
 
+- scope: meta.directive.syntax.keyword
+  settings:
+    foreground: '#75789c'
+
+- scope: meta.directive.syntax.language
+  settings:
+    foreground: '#98a8b3'
+
+## inherit from comment.*
+# - scope: meta.directive.syntax.context
+#   settings:
+#     foreground: '#758B99'
+
 # LINTING #####################################################################
 
 - scope: markup.warning.sublime_linter
@@ -634,7 +647,7 @@ settings:
     meta.group.capturing.regexp
     meta.group.capturing.regexp
   settings:
-    background: '#7BB664 89'
+    background: '#7BB66489'
 
 - name: Regex Outer Punc
   scope: punctuation.definition.string.regexp

--- a/nested/build/ecmascript/ecmascript-nest.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-nest.sublime-syntax
@@ -84,29 +84,32 @@ variables:
   idEnd: '(?=\$[^\{]|[^_‍‍{{ID_Continue}}]|$)'
   syntaxDirectiveHead: '(\s*syntax\s*:\s*)'
   syntaxDirectiveTail: '\s*(\*\/)\s*(({{identifier}}))?(?=\s*`)'
-  syntaxDirective_CSS: '[Cc](?:ss|SS){{syntaxDirectiveTail}}'
-  syntaxDirective_CSS_STYLE: '[Cc](?:ss|SS)[.#][Ss]tyle{{syntaxDirectiveTail}}'
-  syntaxDirective_DOT: '[Dd](?:ot|OT){{syntaxDirectiveTail}}'
-  syntaxDirective_GLSL: '[Gg](?:lsl|LSL){{syntaxDirectiveTail}}'
-  syntaxDirective_HTML: '[Hh](?:tml|TML){{syntaxDirectiveTail}}'
-  syntaxDirective_JS: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_VALUE: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Vv]alue{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_METHOD: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Mm]ethod{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_REGEXP: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Rr]egexp?{{syntaxDirectiveTail}}'
+  syntaxDirective_CSS: '([Cc](?:ss|SS))(){{syntaxDirectiveTail}}'
+  syntaxDirective_CSS_STYLE: '([Cc](?:ss|SS))([.#][Ss]tyle){{syntaxDirectiveTail}}'
+  syntaxDirective_DOT: '([Dd](?:ot|OT))(){{syntaxDirectiveTail}}'
+  syntaxDirective_GLSL: '([Gg](?:lsl|LSL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_HTML: '([Hh](?:tml|TML))(){{syntaxDirectiveTail}}'
+  syntaxDirective_JS: '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)(){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_VALUE: '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Vv]alue){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_METHOD: '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Mm]ethod){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_REGEXP: >-
+    ([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Rr]egexp?){{syntaxDirectiveTail}}
   syntaxDirective_JS_OBJECT_LITERAL: >-
-    [Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Oo]bject-[Ll]iteral{{syntaxDirectiveTail}}
+    ([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Oo]bject-[Ll]iteral){{syntaxDirectiveTail}}
   syntaxDirective_JS_SIMPLE: >-
-    [Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?-[Ss](?:imple|IMPLE){{syntaxDirectiveTail}}
-  syntaxDirective_JSON: '[Jj](?:son|SON){{syntaxDirectiveTail}}'
-  syntaxDirective_LUA: '[Ll](?:ua|UA){{syntaxDirectiveTail}}'
-  syntaxDirective_MARKDOWN: '[Mm](?:ark[Dd](?:own|OWN)|ARKDOWN|[Dd]){{syntaxDirectiveTail}}'
-  syntaxDirective_SHELL: '(?:[Bb](?:ash|ASH)|[Ss](?:hell|HELL)){{syntaxDirectiveTail}}'
-  syntaxDirective_SQL: '[Ss](?:ql|QL){{syntaxDirectiveTail}}'
-  syntaxDirective_SUBLIME_SYNTAX: '[Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX){{syntaxDirectiveTail}}'
+    ([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?-[Ss](?:imple|IMPLE)){{syntaxDirectiveTail}}
+  syntaxDirective_JSON: '([Jj](?:son|SON))(){{syntaxDirectiveTail}}'
+  syntaxDirective_LUA: '([Ll](?:ua|UA))(){{syntaxDirectiveTail}}'
+  syntaxDirective_MARKDOWN: '([Mm](?:ark[Dd](?:own|OWN)|ARKDOWN|[Dd]))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SHELL: '([Bb](?:ash|ASH)|[Ss](?:hell|HELL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SQL: '([Ss](?:ql|QL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SUBLIME_SYNTAX: '([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))(){{syntaxDirectiveTail}}'
   syntaxDirective_SUBLIME_SYNTAX_CONTEXT: >-
-    [Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX)[.#][Cc]ontexts?{{syntaxDirectiveTail}}
-  syntaxDirective_XML: '[Xx](?:ml|ML){{syntaxDirectiveTail}}'
-  syntaxDirective_YAML: '[Yy](?:aml|AML){{syntaxDirectiveTail}}'
+    ([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))([.#][Cc]ontexts?){{syntaxDirectiveTail}}
+  syntaxDirective_SUBLIME_SYNTAX_REGEX: >-
+    ([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))([.#][Rr]egexp?){{syntaxDirectiveTail}}
+  syntaxDirective_XML: '([Xx](?:ml|ML))(){{syntaxDirectiveTail}}'
+  syntaxDirective_YAML: '([Yy](?:aml|AML))(){{syntaxDirectiveTail}}'
   syntaxDirective: |-
     (?x)
       ((\/\*)){{syntaxDirectiveHead}}
@@ -128,6 +131,7 @@ variables:
         | {{syntaxDirective_SQL}}
         | {{syntaxDirective_SUBLIME_SYNTAX}}
         | {{syntaxDirective_SUBLIME_SYNTAX_CONTEXT}}
+        | {{syntaxDirective_SUBLIME_SYNTAX_REGEX}}
         | {{syntaxDirective_XML}}
         | {{syntaxDirective_YAML}}
       )

--- a/nested/build/ecmascript/ecmascript-safe.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-safe.sublime-syntax
@@ -84,29 +84,32 @@ variables:
   idEnd: '(?=[^\$_‍‍{{ID_Continue}}]|$)'
   syntaxDirectiveHead: '(\s*syntax\s*:\s*)'
   syntaxDirectiveTail: '\s*(\*\/)\s*(({{identifier}}))?(?=\s*`)'
-  syntaxDirective_CSS: '[Cc](?:ss|SS){{syntaxDirectiveTail}}'
-  syntaxDirective_CSS_STYLE: '[Cc](?:ss|SS)[.#][Ss]tyle{{syntaxDirectiveTail}}'
-  syntaxDirective_DOT: '[Dd](?:ot|OT){{syntaxDirectiveTail}}'
-  syntaxDirective_GLSL: '[Gg](?:lsl|LSL){{syntaxDirectiveTail}}'
-  syntaxDirective_HTML: '[Hh](?:tml|TML){{syntaxDirectiveTail}}'
-  syntaxDirective_JS: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_VALUE: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Vv]alue{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_METHOD: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Mm]ethod{{syntaxDirectiveTail}}'
-  syntaxDirective_JS_REGEXP: '[Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Rr]egexp?{{syntaxDirectiveTail}}'
+  syntaxDirective_CSS: '([Cc](?:ss|SS))(){{syntaxDirectiveTail}}'
+  syntaxDirective_CSS_STYLE: '([Cc](?:ss|SS))([.#][Ss]tyle){{syntaxDirectiveTail}}'
+  syntaxDirective_DOT: '([Dd](?:ot|OT))(){{syntaxDirectiveTail}}'
+  syntaxDirective_GLSL: '([Gg](?:lsl|LSL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_HTML: '([Hh](?:tml|TML))(){{syntaxDirectiveTail}}'
+  syntaxDirective_JS: '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)(){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_VALUE: '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Vv]alue){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_METHOD: '([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Mm]ethod){{syntaxDirectiveTail}}'
+  syntaxDirective_JS_REGEXP: >-
+    ([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Rr]egexp?){{syntaxDirectiveTail}}
   syntaxDirective_JS_OBJECT_LITERAL: >-
-    [Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?[.#][Oo]bject-[Ll]iteral{{syntaxDirectiveTail}}
+    ([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?)([.#][Oo]bject-[Ll]iteral){{syntaxDirectiveTail}}
   syntaxDirective_JS_SIMPLE: >-
-    [Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?-[Ss](?:imple|IMPLE){{syntaxDirectiveTail}}
-  syntaxDirective_JSON: '[Jj](?:son|SON){{syntaxDirectiveTail}}'
-  syntaxDirective_LUA: '[Ll](?:ua|UA){{syntaxDirectiveTail}}'
-  syntaxDirective_MARKDOWN: '[Mm](?:ark[Dd](?:own|OWN)|ARKDOWN|[Dd]){{syntaxDirectiveTail}}'
-  syntaxDirective_SHELL: '(?:[Bb](?:ash|ASH)|[Ss](?:hell|HELL)){{syntaxDirectiveTail}}'
-  syntaxDirective_SQL: '[Ss](?:ql|QL){{syntaxDirectiveTail}}'
-  syntaxDirective_SUBLIME_SYNTAX: '[Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX){{syntaxDirectiveTail}}'
+    ([Jj](?:ava|AVA)?[Ss](?:cript|CRIPT)?-[Ss](?:imple|IMPLE)){{syntaxDirectiveTail}}
+  syntaxDirective_JSON: '([Jj](?:son|SON))(){{syntaxDirectiveTail}}'
+  syntaxDirective_LUA: '([Ll](?:ua|UA))(){{syntaxDirectiveTail}}'
+  syntaxDirective_MARKDOWN: '([Mm](?:ark[Dd](?:own|OWN)|ARKDOWN|[Dd]))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SHELL: '([Bb](?:ash|ASH)|[Ss](?:hell|HELL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SQL: '([Ss](?:ql|QL))(){{syntaxDirectiveTail}}'
+  syntaxDirective_SUBLIME_SYNTAX: '([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))(){{syntaxDirectiveTail}}'
   syntaxDirective_SUBLIME_SYNTAX_CONTEXT: >-
-    [Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX)[.#][Cc]ontexts?{{syntaxDirectiveTail}}
-  syntaxDirective_XML: '[Xx](?:ml|ML){{syntaxDirectiveTail}}'
-  syntaxDirective_YAML: '[Yy](?:aml|AML){{syntaxDirectiveTail}}'
+    ([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))([.#][Cc]ontexts?){{syntaxDirectiveTail}}
+  syntaxDirective_SUBLIME_SYNTAX_REGEX: >-
+    ([Ss](?:ublime-?[Ss]yntax|UBLIME-SYNTAX))([.#][Rr]egexp?){{syntaxDirectiveTail}}
+  syntaxDirective_XML: '([Xx](?:ml|ML))(){{syntaxDirectiveTail}}'
+  syntaxDirective_YAML: '([Yy](?:aml|AML))(){{syntaxDirectiveTail}}'
   syntaxDirective: |-
     (?x)
       ((\/\*)){{syntaxDirectiveHead}}
@@ -128,6 +131,7 @@ variables:
         | {{syntaxDirective_SQL}}
         | {{syntaxDirective_SUBLIME_SYNTAX}}
         | {{syntaxDirective_SUBLIME_SYNTAX_CONTEXT}}
+        | {{syntaxDirective_SUBLIME_SYNTAX_REGEX}}
         | {{syntaxDirective_XML}}
         | {{syntaxDirective_YAML}}
       )

--- a/nested/build/ecmascript/excelsior.tmTheme
+++ b/nested/build/ecmascript/excelsior.tmTheme
@@ -326,6 +326,24 @@
       </dict>
       <dict>
         <key>scope</key>
+        <string>meta.directive.syntax.keyword</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#75789c</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.directive.syntax.language</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#98a8b3</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
         <string>markup.warning.sublime_linter</string>
         <key>settings</key>
         <dict>
@@ -1223,7 +1241,7 @@ string.regexp punctuation.definition.assertion.positive</string>
         <key>settings</key>
         <dict>
           <key>background</key>
-          <string>#7BB664 89</string>
+          <string>#7BB66489</string>
         </dict>
       </dict>
       <dict>


### PR DESCRIPTION
### Info
This PR adds commands for inserting/toggling nested syntax directives on template literal strings.

The command is bound to the [d/irk](http://ascii-table.com/pronunciation-guide.php) key with the ['primary' modifier](https://www.sublimetext.com/docs/3/key_bindings.html#modifiers), i.e., `Ctrl+'` on Windows/Linux and `⌘+'` on MacOS.

### Demo
![ecmascript-command-nested-syntax-directives](https://user-images.githubusercontent.com/1456400/56872948-5b31e500-69e3-11e9-89f8-0f9f4d0b7a41.gif)

### Features
 - works with tags
 - first field marker is to placeholder for language
 - exit field marker is within string
 - preserves selection (exit field marker highlights previous selection if present)

### Also included in this PR
 - scoping and subtle coloration for syntax directives
 - regexp context for nested sublime-syntax (dogfooded in some of the build sources)
 - typo fix for regexp group color