### PR TITLE
Patch for 'normally illegal' method names

### DIFF
--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -3622,6 +3622,14 @@ contexts:
         2: variable.other.readwrite.property.shorthand.initCap.es
         3: variable.other.readwrite.property.shorthand.es
       set: literalObject_AFTER_SHORTHAND
+    # NORMALLY ILLEGAL NAMED METHOD
+    - match: '((({{identifierName}})))\s*(\()'
+      captures:
+        1: entity.name.method.js # ^BS -- monokai
+        2: entity.name.method.es
+        3: variable.other.readwrite.property.es
+        4: punctuation.definition.parameters.method.begin.es
+      set: [ literalObject_AFTER_AE, method_AFTER_PARAMS, parameters ]
     # NORMALLY ILLEGAL NAME
     - match: '(({{identifierName}}))'
       captures:

--- a/nested/build/ecmascript/ecmascript-nest.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-nest.sublime-syntax
@@ -3677,6 +3677,16 @@ contexts:
         '2': variable.other.readwrite.property.shorthand.initCap.es
         '3': variable.other.readwrite.property.shorthand.es
       set: literalObject_AFTER_SHORTHAND
+    - match: '((({{identifierName}})))\s*(\()'
+      captures:
+        '1': entity.name.method.js
+        '2': entity.name.method.es
+        '3': variable.other.readwrite.property.es
+        '4': punctuation.definition.parameters.method.begin.es
+      set:
+        - literalObject_AFTER_AE
+        - method_AFTER_PARAMS
+        - parameters
     - match: '(({{identifierName}}))(?=\$\{)'
       captures:
         '1': constant.other.object.key.js string.unquoted.label.js

--- a/nested/build/ecmascript/ecmascript-safe.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-safe.sublime-syntax
@@ -3415,6 +3415,16 @@ contexts:
         '2': variable.other.readwrite.property.shorthand.initCap.es
         '3': variable.other.readwrite.property.shorthand.es
       set: literalObject_AFTER_SHORTHAND
+    - match: '((({{identifierName}})))\s*(\()'
+      captures:
+        '1': entity.name.method.js
+        '2': entity.name.method.es
+        '3': variable.other.readwrite.property.es
+        '4': punctuation.definition.parameters.method.begin.es
+      set:
+        - literalObject_AFTER_AE
+        - method_AFTER_PARAMS
+        - parameters
     - match: '(({{identifierName}}))'
       captures:
         '1': constant.other.object.key.js string.unquoted.label.js


### PR DESCRIPTION
Simple patch disambiguates normally illegal name between method/property in `literalObject_OPEN` context rather than in `literalObject_AFTER_SHORTHAND`.

![Screen Shot 2019-06-28 at 8 00 58 PM](https://user-images.githubusercontent.com/1456400/60378961-951d6880-99df-11e9-879d-21c696d6a2b2.png)
![Screen Shot 2019-06-28 at 8 01 21 PM](https://user-images.githubusercontent.com/1456400/60378962-98b0ef80-99df-11e9-96a2-726934a157b0.png)
