### PR TITLE
better handling of interpolated spans in html (addresses #70)

### DIFF
--- a/nested/build/base-packages/HTML/HTML.sublime-syntax
+++ b/nested/build/base-packages/HTML/HTML.sublime-syntax
@@ -203,15 +203,7 @@ contexts:
           scope: punctuation.definition.tag.end.html
           pop: true
         - include: tag-attributes
-    # Special case for handling ES tagged template where interpolation occurs in
-    # tag name position:
-    #
-    #   <${expression} attr=val>
-    #
-    # If we did not include this case, the ‘<’ would be scoped as ordinary
-    # chardata.
-    #
-    - match: '(</?)(?=\$\{)'
+    - match: '(</?)(?=\${)'
       captures:
         '1': punctuation.definition.tag.begin.html
       push:
@@ -276,7 +268,7 @@ contexts:
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
         - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
-        - match: =(?=\$\{)
+        - match: '=(?=\$\{)'
           scope: punctuation.separator.key-value.html
           pop: true
         - match: =
@@ -351,7 +343,7 @@ contexts:
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
         - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
-        - match: =(?=\$\{)
+        - match: '=(?=\$\{)'
           scope: punctuation.separator.key-value.html
           pop: true
         - match: =
@@ -422,17 +414,7 @@ contexts:
     - meta_scope: meta.attribute-with-value.html
     - include: immediately-pop
   tag-generic-attribute-equals:
-    # The first match here captures cases like this in ES tagged templates:
-    #
-    #   <foo bar=${expression} baz=${expression}>
-    #
-    # If we did not treat this as a special case, ‘baz=’ would end up being seen
-    # as an unquoted attribute value.
-    #
-    # Because there are various places where = is matched with special handling
-    # for well-known attributes, this repeats a few times elsewhere.
-    #
-    - match: =(?=\$\{)
+    - match: '=(?=\$\{)'
       scope: punctuation.separator.key-value.html
       pop: true
     - match: =
@@ -471,7 +453,7 @@ contexts:
     - meta_scope: meta.attribute-with-value.class.html
     - include: immediately-pop
   tag-class-attribute-equals:
-    - match: =(?=\$\{)
+    - match: '=(?=\$\{)'
       scope: punctuation.separator.key-value.html
       pop: true
     - match: =
@@ -512,7 +494,7 @@ contexts:
     - meta_scope: meta.attribute-with-value.id.html
     - include: immediately-pop
   tag-id-attribute-equals:
-    - match: =(?=\$\{)
+    - match: '=(?=\$\{)'
       scope: punctuation.separator.key-value.html
       pop: true
     - match: =
@@ -553,7 +535,7 @@ contexts:
     - meta_scope: meta.attribute-with-value.style.html
     - include: immediately-pop
   tag-style-attribute-equals:
-    - match: =(?=\$\{)
+    - match: '=(?=\$\{)'
       scope: punctuation.separator.key-value.html
       pop: true
     - match: =
@@ -598,7 +580,7 @@ contexts:
     - meta_scope: meta.attribute-with-value.event.html
     - include: immediately-pop
   tag-event-attribute-equals:
-    - match: =(?=\$\{)
+    - match: '=(?=\$\{)'
       scope: punctuation.separator.key-value.html
       pop: true
     - match: =

--- a/nested/build/base-packages/HTML/HTML.sublime-syntax
+++ b/nested/build/base-packages/HTML/HTML.sublime-syntax
@@ -4,14 +4,7 @@ name: Ecmascript nested syntax - HTML
 scope: text.html.basic.nested.es
 variables:
   attribute_char: '(?:[^ "''>/=\x00-\x1f\x7f-\x9f])'
-  # The first alternative in the unquoted_attribute_value pattern captures cases
-  # like this in ES tagged templates:
-  #
-  #   <foo bar=${expression} baz=${expression}>
-  #
-  # If we did not treat this as a special case, ‘baz=’ would end up being seen
-  # as an unquoted attribute value.
-  unquoted_attribute_value: '(?=\$\{)|(?:[^\s<>/''''"]|/(?!>))+'
+  unquoted_attribute_value: '(?:[^\s<>/''''"]|/(?!>))+'
   not_equals_lookahead: '(?=\s*[^\s=])'
   block_tag_name: |-
     (?ix:
@@ -283,6 +276,9 @@ contexts:
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
         - meta_content_scope: meta.tag.style.begin.html meta.attribute-with-value.html
+        - match: =(?=\$\{)
+          scope: punctuation.separator.key-value.html
+          pop: true
         - match: =
           scope: punctuation.separator.key-value.html
           set:
@@ -355,6 +351,9 @@ contexts:
       scope: meta.attribute-with-value.html entity.other.attribute-name.html
       set:
         - meta_content_scope: meta.tag.script.begin.html meta.attribute-with-value.html
+        - match: =(?=\$\{)
+          scope: punctuation.separator.key-value.html
+          pop: true
         - match: =
           scope: punctuation.separator.key-value.html
           set:
@@ -423,6 +422,19 @@ contexts:
     - meta_scope: meta.attribute-with-value.html
     - include: immediately-pop
   tag-generic-attribute-equals:
+    # The first match here captures cases like this in ES tagged templates:
+    #
+    #   <foo bar=${expression} baz=${expression}>
+    #
+    # If we did not treat this as a special case, ‘baz=’ would end up being seen
+    # as an unquoted attribute value.
+    #
+    # Because there are various places where = is matched with special handling
+    # for well-known attributes, this repeats a few times elsewhere.
+    #
+    - match: =(?=\$\{)
+      scope: punctuation.separator.key-value.html
+      pop: true
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-generic-attribute-value
@@ -459,6 +471,9 @@ contexts:
     - meta_scope: meta.attribute-with-value.class.html
     - include: immediately-pop
   tag-class-attribute-equals:
+    - match: =(?=\$\{)
+      scope: punctuation.separator.key-value.html
+      pop: true
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-class-attribute-value
@@ -497,6 +512,9 @@ contexts:
     - meta_scope: meta.attribute-with-value.id.html
     - include: immediately-pop
   tag-id-attribute-equals:
+    - match: =(?=\$\{)
+      scope: punctuation.separator.key-value.html
+      pop: true
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-id-attribute-value
@@ -535,6 +553,9 @@ contexts:
     - meta_scope: meta.attribute-with-value.style.html
     - include: immediately-pop
   tag-style-attribute-equals:
+    - match: =(?=\$\{)
+      scope: punctuation.separator.key-value.html
+      pop: true
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-style-attribute-value
@@ -577,6 +598,9 @@ contexts:
     - meta_scope: meta.attribute-with-value.event.html
     - include: immediately-pop
   tag-event-attribute-equals:
+    - match: =(?=\$\{)
+      scope: punctuation.separator.key-value.html
+      pop: true
     - match: =
       scope: punctuation.separator.key-value.html
       set: tag-event-attribute-value

--- a/nested/build/base-packages/HTML/HTML.sublime-syntax
+++ b/nested/build/base-packages/HTML/HTML.sublime-syntax
@@ -4,7 +4,14 @@ name: Ecmascript nested syntax - HTML
 scope: text.html.basic.nested.es
 variables:
   attribute_char: '(?:[^ "''>/=\x00-\x1f\x7f-\x9f])'
-  unquoted_attribute_value: '(?:[^\s<>/''''"]|/(?!>))+'
+  # The first alternative in the unquoted_attribute_value pattern captures cases
+  # like this in ES tagged templates:
+  #
+  #   <foo bar=${expression} baz=${expression}>
+  #
+  # If we did not treat this as a special case, ‘baz=’ would end up being seen
+  # as an unquoted attribute value.
+  unquoted_attribute_value: '(?=\$\{)|(?:[^\s<>/''''"]|/(?!>))+'
   not_equals_lookahead: '(?=\s*[^\s=])'
   block_tag_name: |-
     (?ix:
@@ -197,6 +204,23 @@ contexts:
       captures:
         '1': punctuation.definition.tag.begin.html
         '2': entity.name.tag.other.html
+      push:
+        - meta_scope: meta.tag.other.html
+        - match: '(?: ?/)?>'
+          scope: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-attributes
+    # Special case for handling ES tagged template where interpolation occurs in
+    # tag name position:
+    #
+    #   <${expression} attr=val>
+    #
+    # If we did not include this case, the ‘<’ would be scoped as ordinary
+    # chardata.
+    #
+    - match: '(</?)(?=\$\{)'
+      captures:
+        '1': punctuation.definition.tag.begin.html
       push:
         - meta_scope: meta.tag.other.html
         - match: '(?: ?/)?>'

--- a/nested/src/syntax.js
+++ b/nested/src/syntax.js
@@ -13,7 +13,7 @@ const interp_escape_lookahead = () => ({
 	//
 	// Because there are various places where = is matched with special handling
 	// for well-known attributes, this repeats a few times elsewhere.
-	match: /* syntax: sublime-syntax.regex */ `=(?=\\$\\{)`,
+	match: String.raw /* syntax: sublime-syntax.regex */ `=(?=\$\{)`,
 	scope: 'punctuation.separator.key-value.html',
 	pop: true,
 });
@@ -37,7 +37,7 @@ const h_syntax_transforms = {
 
 	'text.html.basic': {
 		'$.variables': (h_vars) => {
-			h_vars.unquoted_attribute_value = /* syntax: sublime-syntax.regexp */ `(?:[^\\s<>/''"]|/(?!>))+`;
+			h_vars.unquoted_attribute_value = String.raw /* syntax: sublime-syntax.regexp */ `(?:[^\s<>/''"]|/(?!>))+`;
 		},
 
 		'$.contexts["style-type-attribute"][0].set': (a_rules) => {
@@ -67,7 +67,7 @@ const h_syntax_transforms = {
 
 				// If we did not include this case, the ‘<’ would be scoped as ordinary
 				// chardata.
-				match: /* syntax: sublime-syntax.regexp */ `(</?)(?=\\$\{)`,
+				match: String.raw /* syntax: sublime-syntax.regexp */ `(</?)(?=\$\{)`,
 				captures: {
 					1: 'punctuation.definition.tag.begin.html',
 				},


### PR DESCRIPTION
Two tweaks for the baked-in HTML def used for tagged templates. Even though `${` pops out of HTML, we can still perform a _lookahead_ for it in the HTML def. This lets us make special exceptions that handle real world usage patterns from ES without really giving up on correctness for uninterpolated HTML source.

![image](https://user-images.githubusercontent.com/6257356/61990017-63131c80-b006-11e9-8ebb-40e4173765de.png)

![image](https://user-images.githubusercontent.com/6257356/61990027-77571980-b006-11e9-8144-c54c20093854.png)

It hadn’t occurred to me previously that this was possible. This approach could probably help in a few other places, too (or maybe we’re already doing it elsewhere and I just didn’t notice).