### PR TITLE
add logical assignment &&= and ??=

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,6 @@ in ‘.regexp’ do not also have ‘.es’.
       - `keyword.operator.assignment`
       - `keyword.operator.assignment.conditional`
       - `keyword.operator.assignment.conditional.default` (default initializer)
-      - `keyword.operator.assignment.conditional.mallet` (`||=` -- used to be in Babel)
       - `keyword.operator.unary.delete`
     - **Augmented**
       - `keyword.operator.assignment.augmented`
@@ -541,6 +540,9 @@ in ‘.regexp’ do not also have ‘.es’.
       - `keyword.operator.assignment.augmented.bitwise.shift.left`
       - `keyword.operator.assignment.augmented.bitwise.shift.right`
       - `keyword.operator.assignment.augmented.bitwise.shift.right.unsigned`
+      - `keyword.operator.assignment.augmented.logical.and`
+      - `keyword.operator.assignment.augmented.logical.or`
+      - `keyword.operator.assignment.augmented.logical.or.nullish-coalescing`
   - **Bitwise**
     - `keyword.operator.bitwise`
     - `keyword.operator.bitwise.logical`

--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -2438,12 +2438,8 @@ contexts:
       set: ae_AFTER_THING
 
   ae_INFIX_OPS:
-    # NULLISH COALESCING
-    - match: '\?\?'
-      scope: keyword.operator.logical.or.nullish-coalescing.es
-      set: assignmentExpression
     # TERNARY
-    - match: '\?'
+    - match: '\?(?!\?)'
       scope: keyword.operator.ternary.if.es
       set: ae_TERNARY_AFTER_QUESTION
     # ARITHMETIC
@@ -2479,11 +2475,14 @@ contexts:
       scope: keyword.operator.comparison.non-equality.coercive.es
       set: assignmentExpression
     # LOGICAL
-    - match: '&&'
+    - match: '&&(?!=)'
       scope: keyword.operator.logical.and.es
       set: assignmentExpression
     - match: '\|\|(?!=)'
       scope: keyword.operator.logical.or.es
+      set: assignmentExpression
+    - match: '\?\?(?!=)'
+      scope: keyword.operator.logical.or.nullish-coalescing.es
       set: assignmentExpression
     # BITWISE LOGICAL
     - match: '&(?!=)'
@@ -2556,9 +2555,15 @@ contexts:
     - match: '%='
       scope: keyword.operator.assignment.augmented.arithmetic.modulo.es
       set: assignmentExpression
-    # MALLET
+    # LOGICAL
+    - match: '&&='
+      scope: keyword.operator.assignment.augmented.logical.and.es
+      set: assignmentExpression
     - match: '\|\|='
-      scope: keyword.operator.assignment.conditional.mallet.es
+      scope: keyword.operator.assignment.augmented.logical.or.es
+      set: assignmentExpression
+    - match: '\?\?='
+      scope: keyword.operator.assignment.augmented.logical.or.nullish-coalescing.es
       set: assignmentExpression
     # BITWISE LOGICAL
     - match: '&='
@@ -3217,10 +3222,7 @@ contexts:
       scope: support.function.builtin.es
       set: ae_NO_IN_AFTER_THING
   ae_NO_IN_INFIX_OPS:
-    - match: '\?\?'
-      scope: keyword.operator.logical.or.nullish-coalescing.es
-      set: assignmentExpression_NO_IN
-    - match: '\?'
+    - match: '\?(?!\?)'
       scope: keyword.operator.ternary.if.es
       set: ae_NO_IN_TERNARY_AFTER_QUESTION
     - match: '\+(?!=)'
@@ -3260,11 +3262,14 @@ contexts:
     - match: '!='
       scope: keyword.operator.comparison.non-equality.coercive.es
       set: assignmentExpression_NO_IN
-    - match: '&&'
+    - match: '&&(?!=)'
       scope: keyword.operator.logical.and.es
       set: assignmentExpression_NO_IN
     - match: '\|\|(?!=)'
       scope: keyword.operator.logical.or.es
+      set: assignmentExpression_NO_IN
+    - match: '\?\?(?!=)'
+      scope: keyword.operator.logical.or.nullish-coalescing.es
       set: assignmentExpression_NO_IN
     - match: '&(?!=)'
       scope: keyword.operator.bitwise.logical.and.es
@@ -3324,8 +3329,14 @@ contexts:
     - match: '%='
       scope: keyword.operator.assignment.augmented.arithmetic.modulo.es
       set: assignmentExpression_NO_IN
+    - match: '&&='
+      scope: keyword.operator.assignment.augmented.logical.and.es
+      set: assignmentExpression_NO_IN
     - match: '\|\|='
-      scope: keyword.operator.assignment.conditional.mallet.es
+      scope: keyword.operator.assignment.augmented.logical.or.es
+      set: assignmentExpression_NO_IN
+    - match: '\?\?='
+      scope: keyword.operator.assignment.augmented.logical.or.nullish-coalescing.es
       set: assignmentExpression_NO_IN
     - match: '&='
       scope: keyword.operator.assignment.augmented.bitwise.logical.and.es

--- a/nested/build/ecmascript/ecmascript-nest.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-nest.sublime-syntax
@@ -2541,13 +2541,7 @@ contexts:
       scope: support.function.builtin.es
       set: ae_AFTER_THING
   ae_INFIX_OPS:
-    - match: '\?\?(?=\s*\$\{)'
-      scope: keyword.operator.logical.or.nullish-coalescing.es
-      set: assignmentExpression_INTERP
-    - match: \?\?
-      scope: keyword.operator.logical.or.nullish-coalescing.es
-      set: assignmentExpression
-    - match: \?
+    - match: \?(?!\?)
       scope: keyword.operator.ternary.if.es
       set: ae_TERNARY_AFTER_QUESTION
     - match: '\+(?!=)(?=\s*\$\{)'
@@ -2610,10 +2604,10 @@ contexts:
     - match: '!='
       scope: keyword.operator.comparison.non-equality.coercive.es
       set: assignmentExpression
-    - match: '&&(?=\s*\$\{)'
+    - match: '&&(?!=)(?=\s*\$\{)'
       scope: keyword.operator.logical.and.es
       set: assignmentExpression_INTERP
-    - match: '&&'
+    - match: '&&(?!=)'
       scope: keyword.operator.logical.and.es
       set: assignmentExpression
     - match: '\|\|(?!=)(?=\s*\$\{)'
@@ -2621,6 +2615,12 @@ contexts:
       set: assignmentExpression_INTERP
     - match: \|\|(?!=)
       scope: keyword.operator.logical.or.es
+      set: assignmentExpression
+    - match: '\?\?(?!=)(?=\s*\$\{)'
+      scope: keyword.operator.logical.or.nullish-coalescing.es
+      set: assignmentExpression_INTERP
+    - match: \?\?(?!=)
+      scope: keyword.operator.logical.or.nullish-coalescing.es
       set: assignmentExpression
     - match: '&(?!=)(?=\s*\$\{)'
       scope: keyword.operator.bitwise.logical.and.es
@@ -2710,8 +2710,17 @@ contexts:
     - match: '%='
       scope: keyword.operator.assignment.augmented.arithmetic.modulo.es
       set: assignmentExpression
+    - match: '&&=(?=\s*\$\{)'
+      scope: keyword.operator.assignment.augmented.logical.and.es
+      set: assignmentExpression_INTERP
+    - match: '&&='
+      scope: keyword.operator.assignment.augmented.logical.and.es
+      set: assignmentExpression
     - match: \|\|=
-      scope: keyword.operator.assignment.conditional.mallet.es
+      scope: keyword.operator.assignment.augmented.logical.or.es
+      set: assignmentExpression
+    - match: \?\?=
+      scope: keyword.operator.assignment.augmented.logical.or.nullish-coalescing.es
       set: assignmentExpression
     - match: '&='
       scope: keyword.operator.assignment.augmented.bitwise.logical.and.es
@@ -3368,10 +3377,7 @@ contexts:
       scope: support.function.builtin.es
       set: ae_NO_IN_AFTER_THING
   ae_NO_IN_INFIX_OPS:
-    - match: \?\?
-      scope: keyword.operator.logical.or.nullish-coalescing.es
-      set: assignmentExpression_NO_IN
-    - match: \?
+    - match: \?(?!\?)
       scope: keyword.operator.ternary.if.es
       set: ae_NO_IN_TERNARY_AFTER_QUESTION
     - match: \+(?!=)
@@ -3411,11 +3417,14 @@ contexts:
     - match: '!='
       scope: keyword.operator.comparison.non-equality.coercive.es
       set: assignmentExpression_NO_IN
-    - match: '&&'
+    - match: '&&(?!=)'
       scope: keyword.operator.logical.and.es
       set: assignmentExpression_NO_IN
     - match: \|\|(?!=)
       scope: keyword.operator.logical.or.es
+      set: assignmentExpression_NO_IN
+    - match: \?\?(?!=)
+      scope: keyword.operator.logical.or.nullish-coalescing.es
       set: assignmentExpression_NO_IN
     - match: '&(?!=)'
       scope: keyword.operator.bitwise.logical.and.es
@@ -3475,8 +3484,14 @@ contexts:
     - match: '%='
       scope: keyword.operator.assignment.augmented.arithmetic.modulo.es
       set: assignmentExpression_NO_IN
+    - match: '&&='
+      scope: keyword.operator.assignment.augmented.logical.and.es
+      set: assignmentExpression_NO_IN
     - match: \|\|=
-      scope: keyword.operator.assignment.conditional.mallet.es
+      scope: keyword.operator.assignment.augmented.logical.or.es
+      set: assignmentExpression_NO_IN
+    - match: \?\?=
+      scope: keyword.operator.assignment.augmented.logical.or.nullish-coalescing.es
       set: assignmentExpression_NO_IN
     - match: '&='
       scope: keyword.operator.assignment.augmented.bitwise.logical.and.es

--- a/nested/build/ecmascript/ecmascript-nest.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-nest.sublime-syntax
@@ -972,7 +972,7 @@ contexts:
     - match: '{{PLA_anything}}'
       set: classDeclaration_AFTER_BRACE
   classDeclaration_METHOD_COMMON:
-    - match: '((\*))(?=\s*\${)'
+    - match: '((\*))(?=\s*\$\{)'
       captures:
         '1': keyword.generator.asterisk.js
         '2': storage.modifier.generator.asterisk.method.es
@@ -993,7 +993,7 @@ contexts:
       set:
         - classDeclaration_AFTER_BRACE
         - accessorMethod_AFTER_SET_NAME_INTERP
-    - match: '((async))((\s*\*))?(?=\s*\${)'
+    - match: '((async))((\s*\*))?(?=\s*\$\{)'
       captures:
         '1': storage.type.accessor.js
         '2': storage.modifier.async.method.es

--- a/nested/build/ecmascript/ecmascript-safe.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-safe.sublime-syntax
@@ -2269,10 +2269,7 @@ contexts:
       scope: support.function.builtin.es
       set: ae_AFTER_THING
   ae_INFIX_OPS:
-    - match: \?\?
-      scope: keyword.operator.logical.or.nullish-coalescing.es
-      set: assignmentExpression
-    - match: \?
+    - match: \?(?!\?)
       scope: keyword.operator.ternary.if.es
       set: ae_TERNARY_AFTER_QUESTION
     - match: \+(?!=)
@@ -2305,11 +2302,14 @@ contexts:
     - match: '!='
       scope: keyword.operator.comparison.non-equality.coercive.es
       set: assignmentExpression
-    - match: '&&'
+    - match: '&&(?!=)'
       scope: keyword.operator.logical.and.es
       set: assignmentExpression
     - match: \|\|(?!=)
       scope: keyword.operator.logical.or.es
+      set: assignmentExpression
+    - match: \?\?(?!=)
+      scope: keyword.operator.logical.or.nullish-coalescing.es
       set: assignmentExpression
     - match: '&(?!=)'
       scope: keyword.operator.bitwise.logical.and.es
@@ -2375,8 +2375,14 @@ contexts:
     - match: '%='
       scope: keyword.operator.assignment.augmented.arithmetic.modulo.es
       set: assignmentExpression
+    - match: '&&='
+      scope: keyword.operator.assignment.augmented.logical.and.es
+      set: assignmentExpression
     - match: \|\|=
-      scope: keyword.operator.assignment.conditional.mallet.es
+      scope: keyword.operator.assignment.augmented.logical.or.es
+      set: assignmentExpression
+    - match: \?\?=
+      scope: keyword.operator.assignment.augmented.logical.or.nullish-coalescing.es
       set: assignmentExpression
     - match: '&='
       scope: keyword.operator.assignment.augmented.bitwise.logical.and.es
@@ -3002,10 +3008,7 @@ contexts:
       scope: support.function.builtin.es
       set: ae_NO_IN_AFTER_THING
   ae_NO_IN_INFIX_OPS:
-    - match: \?\?
-      scope: keyword.operator.logical.or.nullish-coalescing.es
-      set: assignmentExpression_NO_IN
-    - match: \?
+    - match: \?(?!\?)
       scope: keyword.operator.ternary.if.es
       set: ae_NO_IN_TERNARY_AFTER_QUESTION
     - match: \+(?!=)
@@ -3045,11 +3048,14 @@ contexts:
     - match: '!='
       scope: keyword.operator.comparison.non-equality.coercive.es
       set: assignmentExpression_NO_IN
-    - match: '&&'
+    - match: '&&(?!=)'
       scope: keyword.operator.logical.and.es
       set: assignmentExpression_NO_IN
     - match: \|\|(?!=)
       scope: keyword.operator.logical.or.es
+      set: assignmentExpression_NO_IN
+    - match: \?\?(?!=)
+      scope: keyword.operator.logical.or.nullish-coalescing.es
       set: assignmentExpression_NO_IN
     - match: '&(?!=)'
       scope: keyword.operator.bitwise.logical.and.es
@@ -3109,8 +3115,14 @@ contexts:
     - match: '%='
       scope: keyword.operator.assignment.augmented.arithmetic.modulo.es
       set: assignmentExpression_NO_IN
+    - match: '&&='
+      scope: keyword.operator.assignment.augmented.logical.and.es
+      set: assignmentExpression_NO_IN
     - match: \|\|=
-      scope: keyword.operator.assignment.conditional.mallet.es
+      scope: keyword.operator.assignment.augmented.logical.or.es
+      set: assignmentExpression_NO_IN
+    - match: \?\?=
+      scope: keyword.operator.assignment.augmented.logical.or.nullish-coalescing.es
       set: assignmentExpression_NO_IN
     - match: '&='
       scope: keyword.operator.assignment.augmented.bitwise.logical.and.es

--- a/nested/src/modify-ecmascript.js
+++ b/nested/src/modify-ecmascript.js
@@ -252,7 +252,7 @@ if('nest' === s_mode) {
 
 			insert_rules([
 				...yaml_load(/* syntax: sublime-syntax#contexts */ `
-					- match: ((\\*))(?=\\s*\\$\{)
+					- match: ((\\*))(?=\\s*\\$\\{)
 					  captures:
 					    1: keyword.generator.asterisk.js
 					    2: storage.modifier.generator.asterisk.method.es
@@ -269,7 +269,7 @@ if('nest' === s_mode) {
 					`)], [])),
 
 				...yaml_load(/* syntax: sublime-syntax#contexts */ `
-					- match: ((async))((\\s*\\*))?(?=\\s*\\$\{)
+					- match: ((async))((\\s*\\*))?(?=\\s*\\$\\{)
 					  captures:
 					    1: storage.type.accessor.js
 					    2: storage.modifier.async.method.es


### PR DESCRIPTION
This adds `&&=` and `??=`. The `||=` operator was already present with the historical `mallet` name from an older proposal. The naming pattern of the three (and their non-assignment counterparts) is made more consistent.

This still needs the nested syntax generation. I haven’t looked super deep into it but I think it doesn’t work for me due to `emk` expecting a unix / bash env and I’m on Windows. (There’s no error message — the script seems to run, but its only apparent effect is to open the emk.js file for editing).