### PR TITLE
Arbitrary export names (and some related fixes)

### DIFF
--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -1661,6 +1661,12 @@ contexts:
     - match: '{{identifierName}}'
       scope: entity.name.module.export.es
       set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+    - match: "'"
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set: [ moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER, stringSingle_AFTER_OPEN ]
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set: [ moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER, stringDouble_AFTER_OPEN ]
     - include: other_illegal_pop
 
   moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER:
@@ -1765,7 +1771,21 @@ contexts:
     - match: '{{identifier}}'
       scope: variable.other.readwrite.import.es
       set: moduleDeclaration_AFTER_IMPORT_BINDING_SPECIFIER_AMBIG
+    - match: "'"
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set: [ moduleDeclaration_IMPORT_BINDING_BEFORE_AS, stringSingle_AFTER_OPEN ]
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set: [ moduleDeclaration_IMPORT_BINDING_BEFORE_AS, stringDouble_AFTER_OPEN ]
     - include: other_illegal
+
+  moduleDeclaration_IMPORT_BINDING_BEFORE_AS:
+    - match: '((as)){{idEnd}}'
+      captures:
+        1: keyword.operator.module.js # ^BS
+        2: storage.modifier.module.as.es
+      set: moduleDeclaration_IMPORT_BINDING_AFTER_AS_BEFORE_BRACE_CLOSE
+    - include: other_illegal_pop
 
   moduleDeclaration_IMPORT_BINDING_AFTER_AS_BEFORE_BRACE_CLOSE:
     - match: '{{identifier}}'

--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -93,10 +93,10 @@ variables:
     DataView | (?:Aggregate|Eval|Range|Reference|Syntax|Type|URI)?Error |
     FinalizationRegistry | Float(?:32|64)Array | Function |
     Int(?:8|16|32)Array | Number | Object | Promise | Proxy | RegExp |
-    SharedArrayBuffer | String | Symbol | Uint(?:8(?:Clamped)?|16|32)Array |
-    (?:Weak)?(?:Map|Set) | WeakRef
+    ShadowRealm | SharedArrayBuffer | String | Symbol |
+    Uint(?:8(?:Clamped)?|16|32)Array | (?:Weak)?(?:Map|Set) | WeakRef
   intrinsicFunctions: >-
-    (?:de|en)codeURI(?:Component)? |
+    (?:de|en)codeURI(?:Component)? | (?:un)?escape |
     eval | is(?:Finite|NaN) | parse(?:Float|Int)
 
   # NUMERIC LITERALS ###########################################################
@@ -2542,7 +2542,7 @@ contexts:
         1: support.class.builtin.es
       set: ae_AFTER_THING
     # OBJECTS
-    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect){{idEnd}}'
+    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect|Temporal){{idEnd}}'
       scope: support.variable.builtin.es
       set: ae_AFTER_THING
     # FUNCTIONS
@@ -3323,7 +3323,7 @@ contexts:
       captures:
         1: support.class.builtin.es
       set: ae_NO_IN_AFTER_THING
-    - match: '(?:globalThis|Intl|JSON|Math|Reflect){{idEnd}}'
+    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect|Temporal){{idEnd}}'
       scope: support.variable.builtin.es
       set: ae_NO_IN_AFTER_THING
     - match: '(?x) ((( {{intrinsicFunctions}} )))\s*((\())'

--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -90,10 +90,11 @@ variables:
 
   intrinsicConstructors: >-
     Array(?:Buffer)? | BigInt | Big(Ui|I)nt64Array | Boolean | Date |
-    DataView | (?:Eval|Range|Reference|Syntax|Type|URI)?Error |
-    Float(?:32|64)Array | Function | Int(?:8|16|32)Array |
-    Number | Object | Promise | Proxy | RegExp | SharedArrayBuffer |
-    String | Symbol | Uint(?:8(?:Clamped)?|16|32)Array | (?:Weak)?(?:Map|Set)
+    DataView | (?:Aggregate|Eval|Range|Reference|Syntax|Type|URI)?Error |
+    FinalizationRegistry | Float(?:32|64)Array | Function |
+    Int(?:8|16|32)Array | Number | Object | Promise | Proxy | RegExp |
+    SharedArrayBuffer | String | Symbol | Uint(?:8(?:Clamped)?|16|32)Array |
+    (?:Weak)?(?:Map|Set) | WeakRef
   intrinsicFunctions: >-
     (?:de|en)codeURI(?:Component)? |
     eval | is(?:Finite|NaN) | parse(?:Float|Int)

--- a/ecmascript.sublime-syntax
+++ b/ecmascript.sublime-syntax
@@ -1405,7 +1405,7 @@ contexts:
       captures:
         1: keyword.operator.module.js # ^BS, augmented
         2: storage.modifier.module.namespace.es
-      set: moduleDeclaration_BEFORE_FROM
+      set: moduleDeclaration_EXPORT_BEFORE_AS_ONE
     - match: '((\{))'
       captures:
         1: punctuation.definition.module-binding.begin.es
@@ -1461,7 +1461,7 @@ contexts:
     # ...but I’m not gonna bother with that quite yet.
     - match: '{{identifier}}'
       scope: variable.other.readwrite.export.es
-      set: moduleDeclaration_BEFORE_FROM
+      set: moduleDeclaration_EXPORT_BEFORE_AS_ONE
     - include: other_illegal_pop
 
   moduleDeclaration_AFTER_DEFAULT:
@@ -1634,30 +1634,50 @@ contexts:
       set: [ moduleDeclaration_BEFORE_ASSERT, stringDouble_AFTER_OPEN ]
     - include: other_illegal_pop
 
+  moduleDeclaration_EXPORT_BEFORE_AS_ONE:
+    - match: '((as)){{idEnd}}'
+      captures:
+        1: keyword.operator.module.js # ^BS
+        2: storage.modifier.module.as.es
+      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS_ONE
+    - include: moduleDeclaration_BEFORE_FROM
+
   moduleDeclaration_EXPORT_BINDING_AFTER_BRACE:
     - match: '((\}))'
       captures:
         1: punctuation.definition.module-binding.end.es
         2: meta.brace.curly.js # ^BS
       set: moduleDeclaration_EXPORT_AFTER_BINDING
-    - match: '({{identifier}})\s+((as)){{idEnd}}'
+    - match: '((default)){{idEnd}}'
       captures:
-        1: variable.other.readwrite.export.es
-        2: keyword.operator.module.js # ^BS
-        3: storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - match: '(default)\s+((as)){{idEnd}}'
-      captures:
-        1: storage.modifier.module.default.es
-        2: keyword.operator.module.js # ^BS
-        3: storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - match: '{{identifier}}'
+        1: keyword.operator.module.js # ^BS
+        2: storage.modifier.module.default.es
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+    - match: '{{identifierName}}'
       scope: variable.other.readwrite.export.es
-      set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_AMBIG
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+    - match: "'"
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set: [ moduleDeclaration_EXPORT_BINDING_BEFORE_AS, stringSingle_AFTER_OPEN ]
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set: [ moduleDeclaration_EXPORT_BINDING_BEFORE_AS, stringDouble_AFTER_OPEN ]
     - include: other_illegal
 
+  moduleDeclaration_EXPORT_BINDING_BEFORE_AS:
+    - match: '((as)){{idEnd}}'
+      captures:
+        1: keyword.operator.module.js # ^BS
+        2: storage.modifier.module.as.es
+      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
+    - include: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+
   moduleDeclaration_EXPORT_BINDING_AFTER_AS:
+    - match: '((default)){{idEnd}}'
+      captures:
+        1: keyword.operator.module.js # ^BS
+        2: storage.modifier.module.default.es
+      set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
     - match: '{{identifierName}}'
       scope: entity.name.module.export.es
       set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
@@ -1667,6 +1687,18 @@ contexts:
     - match: '"'
       scope: punctuation.definition.string.quoted.double.begin.es
       set: [ moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER, stringDouble_AFTER_OPEN ]
+    - include: other_illegal_pop
+
+  moduleDeclaration_EXPORT_BINDING_AFTER_AS_ONE:
+    - match: '{{identifierName}}'
+      scope: entity.name.module.export.es
+      set: moduleDeclaration_BEFORE_FROM
+    - match: "'"
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set: [ moduleDeclaration_BEFORE_FROM, stringSingle_AFTER_OPEN ]
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set: [ moduleDeclaration_BEFORE_FROM, stringDouble_AFTER_OPEN ]
     - include: other_illegal_pop
 
   moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER:
@@ -1681,14 +1713,6 @@ contexts:
         2: meta.delimiter.comma.js # ^BS
       set: moduleDeclaration_EXPORT_BINDING_AFTER_BRACE
     - include: other_illegal
-
-  moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_AMBIG:
-    - match: '((as)){{idEnd}}'
-      captures:
-        1: keyword.operator.module.js # ^BS
-        2: storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - include: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
 
   moduleDeclaration_EXPORT_AFTER_BINDING:
     - match: ';'

--- a/nested/build/ecmascript/ecmascript-nest.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-nest.sublime-syntax
@@ -60,12 +60,13 @@ variables:
   jsxNamespaceIdentifier: '({{identifierInitCapStrict}})(\.)'
   intrinsicConstructors: >-
     Array(?:Buffer)? | BigInt | Big(Ui|I)nt64Array | Boolean | Date | DataView |
-    (?:Eval|Range|Reference|Syntax|Type|URI)?Error | Float(?:32|64)Array |
-    Function | Int(?:8|16|32)Array | Number | Object | Promise | Proxy | RegExp
-    | SharedArrayBuffer | String | Symbol | Uint(?:8(?:Clamped)?|16|32)Array |
-    (?:Weak)?(?:Map|Set)
+    (?:Aggregate|Eval|Range|Reference|Syntax|Type|URI)?Error |
+    FinalizationRegistry | Float(?:32|64)Array | Function | Int(?:8|16|32)Array
+    | Number | Object | Promise | Proxy | RegExp | ShadowRealm |
+    SharedArrayBuffer | String | Symbol | Uint(?:8(?:Clamped)?|16|32)Array |
+    (?:Weak)?(?:Map|Set) | WeakRef
   intrinsicFunctions: >-
-    (?:de|en)codeURI(?:Component)? | eval | is(?:Finite|NaN) |
+    (?:de|en)codeURI(?:Component)? | (?:un)?escape | eval | is(?:Finite|NaN) |
     parse(?:Float|Int)
   binNum: '(0[Bb])(?:[01]+(?:_+[01]+)*)(n)?'
   octNum: '(0[Oo])(?:[0-7]+(?:_+[0-7]+)*)(n)?'
@@ -1447,7 +1448,7 @@ contexts:
       captures:
         '1': keyword.operator.module.js
         '2': storage.modifier.module.namespace.es
-      set: moduleDeclaration_BEFORE_FROM
+      set: moduleDeclaration_EXPORT_BEFORE_AS_ONE
     - match: '((\{))'
       captures:
         '1': punctuation.definition.module-binding.begin.es
@@ -1496,7 +1497,7 @@ contexts:
       set: asyncDeclaration_AFTER_FUNCTION
     - match: '{{identifier}}'
       scope: variable.other.readwrite.export.es
-      set: moduleDeclaration_BEFORE_FROM
+      set: moduleDeclaration_EXPORT_BEFORE_AS_ONE
     - match: '{{MAT_word_or_any_one_char}}'
       scope: invalid.illegal.token.es.NDk
       pop: true
@@ -1702,36 +1703,88 @@ contexts:
     - match: '{{MAT_word_or_any_one_char}}'
       scope: invalid.illegal.token.es.NTY
       pop: true
+  moduleDeclaration_EXPORT_BEFORE_AS_ONE:
+    - match: '((as)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.as.es
+      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS_ONE
+    - include: moduleDeclaration_BEFORE_FROM
   moduleDeclaration_EXPORT_BINDING_AFTER_BRACE:
     - match: '((\}))'
       captures:
         '1': punctuation.definition.module-binding.end.es
         '2': meta.brace.curly.js
       set: moduleDeclaration_EXPORT_AFTER_BINDING
-    - match: '({{identifier}})\s+((as)){{idEnd}}'
+    - match: '((default)){{idEnd}}'
       captures:
-        '1': variable.other.readwrite.export.es
-        '2': keyword.operator.module.js
-        '3': storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - match: '(default)\s+((as)){{idEnd}}'
-      captures:
-        '1': storage.modifier.module.default.es
-        '2': keyword.operator.module.js
-        '3': storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - match: '{{identifier}}'
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.default.es
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+    - match: '{{identifierName}}(?=\$\{)'
       scope: variable.other.readwrite.export.es
-      set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_AMBIG
-    - match: '{{MAT_word_or_any_one_char}}'
-      scope: invalid.illegal.token.es.NTc
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS_INTERP
+    - match: '{{identifierName}}'
+      scope: variable.other.readwrite.export.es
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+        - stringDouble_AFTER_OPEN
+    - include: other_illegal
+  moduleDeclaration_EXPORT_BINDING_BEFORE_AS:
+    - match: '((as)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.as.es
+      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
+    - include: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
   moduleDeclaration_EXPORT_BINDING_AFTER_AS:
+    - match: '((default)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.default.es
+      set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
     - match: '{{identifierName}}(?=\$\{)'
       scope: entity.name.module.export.es
       set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_INTERP
     - match: '{{identifierName}}'
       scope: entity.name.module.export.es
       set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+        - stringDouble_AFTER_OPEN
+    - include: other_illegal_pop
+  moduleDeclaration_EXPORT_BINDING_AFTER_AS_ONE:
+    - match: '{{identifierName}}(?=\$\{)'
+      scope: entity.name.module.export.es
+      set: moduleDeclaration_BEFORE_FROM_INTERP
+    - match: '{{identifierName}}'
+      scope: entity.name.module.export.es
+      set: moduleDeclaration_BEFORE_FROM
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_BEFORE_FROM
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_BEFORE_FROM
+        - stringDouble_AFTER_OPEN
     - include: other_illegal_pop
   moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER:
     - match: '((\}))'
@@ -1745,14 +1798,7 @@ contexts:
         '2': meta.delimiter.comma.js
       set: moduleDeclaration_EXPORT_BINDING_AFTER_BRACE
     - match: '{{MAT_word_or_any_one_char}}'
-      scope: invalid.illegal.token.es.NTg
-  moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_AMBIG:
-    - match: '((as)){{idEnd}}'
-      captures:
-        '1': keyword.operator.module.js
-        '2': storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - include: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+      scope: invalid.illegal.token.es.NTc
   moduleDeclaration_EXPORT_AFTER_BINDING:
     - match: ;
       scope: punctuation.terminator.statement.es
@@ -1801,7 +1847,7 @@ contexts:
         '2': meta.brace.curly.js
       set: moduleDeclaration_IMPORT_BINDING_AFTER_BRACE
     - match: '{{MAT_word_or_any_one_char}}'
-      scope: invalid.illegal.token.es.NTk
+      scope: invalid.illegal.token.es.NTg
       pop: true
   moduleDeclaration_IMPORT_BINDING_AFTER_ASTERISK:
     - match: '((as)){{idEnd}}'
@@ -1810,14 +1856,14 @@ contexts:
         '2': storage.modifier.module.as.es
       set: moduleDeclaration_IMPORT_BINDING_AFTER_AS
     - match: '{{MAT_word_or_any_one_char}}'
-      scope: invalid.illegal.token.es.NjA
+      scope: invalid.illegal.token.es.NTk
       pop: true
   moduleDeclaration_IMPORT_BINDING_AFTER_AS:
     - match: '{{identifier}}'
       scope: variable.other.readwrite.import.es
       set: moduleDeclaration_BEFORE_FROM
     - match: '{{MAT_word_or_any_one_char}}'
-      scope: invalid.illegal.token.es.NjE
+      scope: invalid.illegal.token.es.NjA
       pop: true
   moduleDeclaration_IMPORT_BINDING_AFTER_BRACE:
     - match: '((\}))'
@@ -1834,8 +1880,27 @@ contexts:
     - match: '{{identifier}}'
       scope: variable.other.readwrite.import.es
       set: moduleDeclaration_AFTER_IMPORT_BINDING_SPECIFIER_AMBIG
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_IMPORT_BINDING_BEFORE_AS
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_IMPORT_BINDING_BEFORE_AS
+        - stringDouble_AFTER_OPEN
+    - match: '{{MAT_word_or_any_one_char}}'
+      scope: invalid.illegal.token.es.NjE
+  moduleDeclaration_IMPORT_BINDING_BEFORE_AS:
+    - match: '((as)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.as.es
+      set: moduleDeclaration_IMPORT_BINDING_AFTER_AS_BEFORE_BRACE_CLOSE
     - match: '{{MAT_word_or_any_one_char}}'
       scope: invalid.illegal.token.es.NjI
+      pop: true
   moduleDeclaration_IMPORT_BINDING_AFTER_AS_BEFORE_BRACE_CLOSE:
     - match: '{{identifier}}'
       scope: variable.other.readwrite.import.es
@@ -2606,7 +2671,7 @@ contexts:
       captures:
         '1': support.class.builtin.es
       set: ae_AFTER_THING
-    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect){{idEnd}}'
+    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect|Temporal){{idEnd}}'
       scope: support.variable.builtin.es
       set: ae_AFTER_THING
     - match: '(?x) ((( {{intrinsicFunctions}} )))\s*((\())'
@@ -3437,7 +3502,7 @@ contexts:
       captures:
         '1': support.class.builtin.es
       set: ae_NO_IN_AFTER_THING
-    - match: '(?:globalThis|Intl|JSON|Math|Reflect){{idEnd}}'
+    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect|Temporal){{idEnd}}'
       scope: support.variable.builtin.es
       set: ae_NO_IN_AFTER_THING
     - match: '(?x) ((( {{intrinsicFunctions}} )))\s*((\())'
@@ -5639,6 +5704,13 @@ contexts:
         '2': entity.name.method.es
       set: method_AFTER_NAME
     - include: method_AFTER_NAME
+  moduleDeclaration_EXPORT_BINDING_BEFORE_AS_INTERP:
+    - match: '(({{identifierPart}}))(?=\$\{)'
+      scope: variable.other.readwrite.export.es
+    - match: '(({{identifierName}}))'
+      scope: variable.other.readwrite.export.es
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+    - include: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
   moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_INTERP:
     - match: '(({{identifierPart}}))(?=\$\{)'
       scope: entity.name.module.export.es
@@ -5646,6 +5718,13 @@ contexts:
       scope: entity.name.module.export.es
       set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
     - include: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+  moduleDeclaration_BEFORE_FROM_INTERP:
+    - match: '(({{identifierPart}}))(?=\$\{)'
+      scope: entity.name.module.export.es
+    - match: '(({{identifierName}}))'
+      scope: entity.name.module.export.es
+      set: moduleDeclaration_BEFORE_FROM
+    - include: moduleDeclaration_BEFORE_FROM
   ae_AFTER_THING_INTERP:
     - match: '(({{identifierPart}}))(?=\$\{)'
       scope: variable.language.private.es

--- a/nested/build/ecmascript/ecmascript-safe.sublime-syntax
+++ b/nested/build/ecmascript/ecmascript-safe.sublime-syntax
@@ -59,12 +59,13 @@ variables:
   jsxNamespaceIdentifier: '({{identifierInitCapStrict}})(\.)'
   intrinsicConstructors: >-
     Array(?:Buffer)? | BigInt | Big(Ui|I)nt64Array | Boolean | Date | DataView |
-    (?:Eval|Range|Reference|Syntax|Type|URI)?Error | Float(?:32|64)Array |
-    Function | Int(?:8|16|32)Array | Number | Object | Promise | Proxy | RegExp
-    | SharedArrayBuffer | String | Symbol | Uint(?:8(?:Clamped)?|16|32)Array |
-    (?:Weak)?(?:Map|Set)
+    (?:Aggregate|Eval|Range|Reference|Syntax|Type|URI)?Error |
+    FinalizationRegistry | Float(?:32|64)Array | Function | Int(?:8|16|32)Array
+    | Number | Object | Promise | Proxy | RegExp | ShadowRealm |
+    SharedArrayBuffer | String | Symbol | Uint(?:8(?:Clamped)?|16|32)Array |
+    (?:Weak)?(?:Map|Set) | WeakRef
   intrinsicFunctions: >-
-    (?:de|en)codeURI(?:Component)? | eval | is(?:Finite|NaN) |
+    (?:de|en)codeURI(?:Component)? | (?:un)?escape | eval | is(?:Finite|NaN) |
     parse(?:Float|Int)
   binNum: '(0[Bb])(?:[01]+(?:_+[01]+)*)(n)?'
   octNum: '(0[Oo])(?:[0-7]+(?:_+[0-7]+)*)(n)?'
@@ -1293,7 +1294,7 @@ contexts:
       captures:
         '1': keyword.operator.module.js
         '2': storage.modifier.module.namespace.es
-      set: moduleDeclaration_BEFORE_FROM
+      set: moduleDeclaration_EXPORT_BEFORE_AS_ONE
     - match: '((\{))'
       captures:
         '1': punctuation.definition.module-binding.begin.es
@@ -1342,7 +1343,7 @@ contexts:
       set: asyncDeclaration_AFTER_FUNCTION
     - match: '{{identifier}}'
       scope: variable.other.readwrite.export.es
-      set: moduleDeclaration_BEFORE_FROM
+      set: moduleDeclaration_EXPORT_BEFORE_AS_ONE
     - include: other_illegal_pop
   moduleDeclaration_AFTER_DEFAULT:
     - match: 'class{{idEnd}}'
@@ -1523,32 +1524,79 @@ contexts:
         - moduleDeclaration_BEFORE_ASSERT
         - stringDouble_AFTER_OPEN
     - include: other_illegal_pop
+  moduleDeclaration_EXPORT_BEFORE_AS_ONE:
+    - match: '((as)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.as.es
+      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS_ONE
+    - include: moduleDeclaration_BEFORE_FROM
   moduleDeclaration_EXPORT_BINDING_AFTER_BRACE:
     - match: '((\}))'
       captures:
         '1': punctuation.definition.module-binding.end.es
         '2': meta.brace.curly.js
       set: moduleDeclaration_EXPORT_AFTER_BINDING
-    - match: '({{identifier}})\s+((as)){{idEnd}}'
+    - match: '((default)){{idEnd}}'
       captures:
-        '1': variable.other.readwrite.export.es
-        '2': keyword.operator.module.js
-        '3': storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - match: '(default)\s+((as)){{idEnd}}'
-      captures:
-        '1': storage.modifier.module.default.es
-        '2': keyword.operator.module.js
-        '3': storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - match: '{{identifier}}'
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.default.es
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+    - match: '{{identifierName}}'
       scope: variable.other.readwrite.export.es
-      set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_AMBIG
+      set: moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_EXPORT_BINDING_BEFORE_AS
+        - stringDouble_AFTER_OPEN
     - include: other_illegal
+  moduleDeclaration_EXPORT_BINDING_BEFORE_AS:
+    - match: '((as)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.as.es
+      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
+    - include: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
   moduleDeclaration_EXPORT_BINDING_AFTER_AS:
+    - match: '((default)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.default.es
+      set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
     - match: '{{identifierName}}'
       scope: entity.name.module.export.es
       set: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
+        - stringDouble_AFTER_OPEN
+    - include: other_illegal_pop
+  moduleDeclaration_EXPORT_BINDING_AFTER_AS_ONE:
+    - match: '{{identifierName}}'
+      scope: entity.name.module.export.es
+      set: moduleDeclaration_BEFORE_FROM
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_BEFORE_FROM
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_BEFORE_FROM
+        - stringDouble_AFTER_OPEN
     - include: other_illegal_pop
   moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER:
     - match: '((\}))'
@@ -1562,13 +1610,6 @@ contexts:
         '2': meta.delimiter.comma.js
       set: moduleDeclaration_EXPORT_BINDING_AFTER_BRACE
     - include: other_illegal
-  moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER_AMBIG:
-    - match: '((as)){{idEnd}}'
-      captures:
-        '1': keyword.operator.module.js
-        '2': storage.modifier.module.as.es
-      set: moduleDeclaration_EXPORT_BINDING_AFTER_AS
-    - include: moduleDeclaration_AFTER_EXPORT_BINDING_SPECIFIER
   moduleDeclaration_EXPORT_AFTER_BINDING:
     - match: ;
       scope: punctuation.terminator.statement.es
@@ -1644,7 +1685,24 @@ contexts:
     - match: '{{identifier}}'
       scope: variable.other.readwrite.import.es
       set: moduleDeclaration_AFTER_IMPORT_BINDING_SPECIFIER_AMBIG
+    - match: ''''
+      scope: punctuation.definition.string.quoted.single.begin.es
+      set:
+        - moduleDeclaration_IMPORT_BINDING_BEFORE_AS
+        - stringSingle_AFTER_OPEN
+    - match: '"'
+      scope: punctuation.definition.string.quoted.double.begin.es
+      set:
+        - moduleDeclaration_IMPORT_BINDING_BEFORE_AS
+        - stringDouble_AFTER_OPEN
     - include: other_illegal
+  moduleDeclaration_IMPORT_BINDING_BEFORE_AS:
+    - match: '((as)){{idEnd}}'
+      captures:
+        '1': keyword.operator.module.js
+        '2': storage.modifier.module.as.es
+      set: moduleDeclaration_IMPORT_BINDING_AFTER_AS_BEFORE_BRACE_CLOSE
+    - include: other_illegal_pop
   moduleDeclaration_IMPORT_BINDING_AFTER_AS_BEFORE_BRACE_CLOSE:
     - match: '{{identifier}}'
       scope: variable.other.readwrite.import.es
@@ -2332,7 +2390,7 @@ contexts:
       captures:
         '1': support.class.builtin.es
       set: ae_AFTER_THING
-    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect){{idEnd}}'
+    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect|Temporal){{idEnd}}'
       scope: support.variable.builtin.es
       set: ae_AFTER_THING
     - match: '(?x) ((( {{intrinsicFunctions}} )))\s*((\())'
@@ -3069,7 +3127,7 @@ contexts:
       captures:
         '1': support.class.builtin.es
       set: ae_NO_IN_AFTER_THING
-    - match: '(?:globalThis|Intl|JSON|Math|Reflect){{idEnd}}'
+    - match: '(?:globalThis|Atomics|Intl|JSON|Math|Reflect|Temporal){{idEnd}}'
       scope: support.variable.builtin.es
       set: ae_NO_IN_AFTER_THING
     - match: '(?x) ((( {{intrinsicFunctions}} )))\s*((\())'


### PR DESCRIPTION
There was a [normative change last month](https://github.com/tc39/ecma262/pull/2154) that expanded the grammar for ImportSpecifier, ExportSpecifier & ExportFromClause to permit exported binding names to be arbitrary strings that may not be identifier names, like properties.

```js
export { rose as "🌹" };
export { default as "🌹" };
export { "🌹" as "🥀" } from "/rose.mjs";
export * as "🌹" from "/rose.mjs";

import { "🌹" as rose } from "/rose.mjs";
```

![screenshot of previous code block highlighted correctly after these changes](https://user-images.githubusercontent.com/6257356/147108345-6ca73b97-b728-4562-a1cb-67211e73b759.png)

Some invalid patterns for `export NamedExports;` (with no FromClause) will be permitted, e.g. `export { "foo" as bar };`. This follows from the usual can’t see-past-linebreaks issue since this would be legal with `from` and it may not be on the same line. (For similar reasons I think — arbitrary lookahead — the spec itself disallows this via [static semantics rules](https://tc39.es/ecma262/#sec-exports-static-semantics-early-errors), not the grammar proper, i.e. the {} part really is just the same nonterminal that’s also used for `export { "foo" as bar } from "baz"`.

While I was in there I fixed some export grammar issues where there was avoidable same-line sensitivity that could lead to marking a valid token as invalid (“as” was only recognized if same-line with the prior token in some cases). There was also a spot in the export grammar where Identifier should have been IdentifierName.

We were also giving _default_ keywordy scopes inconsistently, e.g. `export { default as default } from "...";` didn’t consider the second `default` a module keyword. That’s arguably true in a technical sense based on how the grammar happens to be structured, but semantically it’s the same magical binding name / pseudo-keyword on both sides of the “as”, so the highlighting distinction was misleading.